### PR TITLE
READMEのbrandsテーブルからancestryの削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,9 @@
 |Column|Type|Options|
 |------|----|-------|
 |name|string|null: false|
-|ancestry|string|null: false|
 
 ### Association
 - has_many :products
-- has_ancestry
 
 
 ## credit_cardsテーブル


### PR DESCRIPTION
# What
スプリントレビューを受けbrandsテーブルを多階層表示から一覧表示に変更

# Why
多階層表記ではなかったため