### PR TITLE
生年月日のバリデーション変更

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,6 @@ class User < ApplicationRecord
   validates :family_name_kana, presence: true, format: { with: /\A([ァ-ン]|ー)+\z/}
   validates :last_name_kana, presence: true, format: { with: /\A([ァ-ン]|ー)+\z/}
   validates :birth_year, presence: true, format: { with: /\A(1[0-9]{3}|2[0-9]{3})+\z/}
-  validates :birth_month, presence: true, format: { with: /\A(0[1-9]{1}|1[0-2]{1})+\z/}
-  validates :birth_day, presence: true, format: { with: /\A(0[1-9]{1}|1[0-9]{1}|2[0-9]{1}|3[0-1]{1})+\z/}
+  validates :birth_month, presence: true, format: { with: /\A([1-9]{1}|1[0-2]{1})+\z/}
+  validates :birth_day, presence: true, format: { with: /\A([1-9]{1}|1[0-9]{1}|2[0-9]{1}|3[0-1]{1})+\z/}
 end


### PR DESCRIPTION
# What
生年月日の月と日のバリデーションを変更

# Why
生年月日の月と日が入力画面では「1」「2」なのに対しバリデーションでは「01」「02」で入るようにしていたため、不正な値としてアラートが出たため入力画面通りに入るようバリデーションを変更しました。