### PR TITLE
スプリントレビュー後　修正の追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
   has_many :purchases
 
   devise :validatable, password_length: 7..128
-  devise :validatable, email_regexp: /\A[a-z\d]+@[a-z\d]+\.\S+\z/
+  devise :validatable, email_regexp: /\A[a-z\d]+@[a-z\d]+\.[a-z\d]+\z/
   validates :nickname, presence: true, length: { in: 1..20}
   validates :family_name, presence: true, format: { with: /\A[ぁ-んァ-ヶー一-龠Ａ-Ｚ]+\z/i}
   validates :last_name, presence: true, format: { with: /\A[ぁ-んァ-ヶー一-龠Ａ-Ｚ]+\z/i}


### PR DESCRIPTION
# What
バリデーションが不適切であるため訂正した

# Why
新規ユーザー登録の際のメールアドレスのバリデーションでドットの後に大文字のアルファベットが入力できるため、小文字のみ入力可能とバリデーションを変更した。