### PR TITLE
【WIP】【サーバサイド】商品詳細表示

### DIFF
--- a/app/assets/javascripts/slider.js
+++ b/app/assets/javascripts/slider.js
@@ -1,0 +1,23 @@
+$(function() {
+  $('#slider').slick({
+  infinite: true,
+  slidesToShow: 1,
+  slidesToScroll: 1,
+  arrows: false,
+  fade: true,
+  asNavFor: '#slider__thumbnail'
+  });
+  $('#slider__thumbnail').slick({
+  accessibility: true,
+  autoplay: true,
+  autoplaySpeed: 4000,
+  speed: 400,
+  arrows: false,
+  infinite: true,
+  slidesToShow: 3,
+  slidesToScroll: 1,
+  asNavFor: '#slider',
+  focusOnSelect: true,
+  });
+  });
+ 

--- a/app/assets/stylesheets/mixin/_mixins.scss
+++ b/app/assets/stylesheets/mixin/_mixins.scss
@@ -41,12 +41,13 @@
   font-size: 16px;
 }
 
-@mixin formbtn-default($bkcolor:$bg-blue,$color: white) {
+@mixin formbtn-default($bkcolor:$bg-blue,$color: white,$f-size: 14px ,$f-weight:normal) {
   display: block;
   width: 100%;
   color: $color;
   line-height: 48px;
-  font-size: 14px;
+  font-size: $f-size;
+  font-size: $f-weight;
   text-align: center;
   background-color: $bkcolor;
   border: none;

--- a/app/assets/stylesheets/products/_show.scss
+++ b/app/assets/stylesheets/products/_show.scss
@@ -1,4 +1,18 @@
 .products-detail-page {
+  #slider__thumbnail{
+    width: 255px;
+    margin: 20px auto 0;
+  }
+
+  .slick-slide:focus {
+    outline: none;
+  }
+  .slick-initialized .slick-slide{
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
   &__bread-crumbs {
     width: 100%;
     border-top: 1px solid #eee;
@@ -18,6 +32,7 @@
     }
   }
   &__main {
+    padding: 40px 0;
     background-color: #F8F8F8;
     &__head {
       padding: 40px;
@@ -42,37 +57,7 @@
               margin: 16px 0 0;
               padding: 0;
               &__ul {
-                display: flex;
-                position: relative;
-                text-align: center;
-                &__li {
-                  display: flex;
-                  flex-direction: column;
-                  width: 560px;
-                  align-items: center;
-                  margin: 0 auto;
-                  padding: 0;
-                  &__img {
-                    object-fit: cover;
-                    width: 100%;
-                    vertical-align: bottom;
-                  }
-                  &__ul {
-                    display: flex;
-                    justify-content: center;
-                    margin-top: 10px;
-                    &__li {
-                      width: 25%;
-                      margin: 0 10px 0 0;
-                      &__img {
-                        object-fit: cover;
-                        height: 87px;
-                        width: 100%;
-                        vertical-align: bottom;
-                      }
-                    }
-                  }
-                }
+
               }
             }
             &__price {
@@ -201,7 +186,7 @@
           padding: 0;
           a {
             display: block;
-            margin: 50px 0 8px;
+            margin: 50px 0 0;
             color: #3CCACE;
             text-decoration: none;
             font-weight: bold;

--- a/app/assets/stylesheets/products/_show.scss
+++ b/app/assets/stylesheets/products/_show.scss
@@ -79,11 +79,12 @@
             &__comments {
               line-height: 1.5;
               font-size: 18px;
-              margin-bottom: 30px;
+              margin:30px 0 0;
             }
             &__table {
               margin-bottom: 20px;
               table {
+                margin: 30px 0;
                 width: 100%;
                 height: 375px;
                 border-collapse: collapse;
@@ -195,6 +196,11 @@
           }
         }
       }
+    }
+  }
+  &__purchase-btn{
+    a{
+      @include formbtn-default($bkcolor:$bg-blue,$color: white,$f-size: 24px ,$f-weight:bold);
     }
   }
 }

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,5 @@
 class ProductsController < ApplicationController
-
+before_action :set_product_images, :set_product_info
 
 
   def index
@@ -15,8 +15,6 @@ class ProductsController < ApplicationController
   end
 
   def show
-    set_product_images
-    set_product_info
     @brand = Brand.find(@product_info.brand_id)
     @category = Category.find(@product_info.category_id)
   end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,5 @@
 class ProductsController < ApplicationController
-before_action :set_product_images, :set_product_info
+before_action :set_product_images, :set_product_info,only: :show
 
 
   def index

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -16,11 +16,16 @@ class ProductsController < ApplicationController
 
   def show
     set_product_images
+    set_product_info
   end
 
 
   private
-  def set_product_images
-    @product_images = ProductImage.where(product_id: params[:id])
-  end
+    def set_product_images
+      @product_images = ProductImage.where(product_id: params[:id])
+    end
+    
+    def set_product_info
+      @product_info = Product.find_by(id: params[:id])
+    end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -17,6 +17,8 @@ class ProductsController < ApplicationController
   def show
     set_product_images
     set_product_info
+    @brand = Brand.find(@product_info.brand_id)
+    @category = Category.find(@product_info.category_id)
   end
 
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -15,7 +15,12 @@ class ProductsController < ApplicationController
   end
 
   def show
+    set_product_images
   end
 
 
+  private
+  def set_product_images
+    @product_images = ProductImage.where(product_id: params[:id])
+  end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,6 +6,8 @@
     %script{src: "https://js.pay.jp/", type: "text/javascript"}
     = csrf_meta_tags
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
+    %link{ rel: "stylesheet", type: "text/css", href: "//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.css"}
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    %script{ type: "text/javascript", src: "//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"}
   %body
     = yield

--- a/app/views/products/_main.html.haml
+++ b/app/views/products/_main.html.haml
@@ -85,11 +85,14 @@
         新規投稿商品
       .top-page-main__pickup-catgory__box__lists
         .top-page-main__pickup-catgory__box__lists__img
-          = image_tag "icon-02.png", width: "220px"
+          =link_to product_path(1) do
+            = image_tag "icon-02.png", width: "220px"
         .top-page-main__pickup-catgory__box__lists__img
-          = image_tag "icon-02.png", width: "220px"
+          =link_to product_path(2) do
+            = image_tag "icon-02.png", width: "220px"
         .top-page-main__pickup-catgory__box__lists__img
-          = image_tag "icon-02.png", width: "220px"
+          =link_to product_path(3) do
+            = image_tag "icon-02.png", width: "220px"
   .top-page-main__pickup-brand
     .top-page-main__pickup-brand__head
       ピックアップブランド

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -1,5 +1,4 @@
-.wrapper
-  = render "shared/header"
+= render "shared/header"
 .products-detail-page
   .products-detail-page__bread-crumbs
     %ul
@@ -22,116 +21,109 @@
       %li
         product1
   .products-detail-page__main
-    .products-detail-page__main__head
-      .products-detail-page__main__head__contents
-        .products-detail-page__main__head__contents__top
-          .products-detail-page__main__head__contents__top__item-box
-            .products-detail-page__main__head__contents__top__item-box__name
-              product1
-            .products-detail-page__main__head__contents__top__item-box__body
-              .products-detail-page__main__head__contents__top__item-box__body__ul
-                .products-detail-page__main__head__contents__top__item-box__body__ul__li
-                  .products-detail-page__main__head__contents__top__item-box__body__ul__li__img
-                    = image_tag "icon-02.png", height:"346px"
-                  .products-detail-page__main__head__contents__top__item-box__body__ul__li__ul
-                    .products-detail-page__main__head__contents__top__item-box__body__ul__li__ul__li
-                      .products-detail-page__main__head__contents__top__item-box__body__ul__li__ul__li__img
-                        = image_tag "icon-02.png", width: "75px",height: "87px"
-                    .products-detail-page__main__head__contents__top__item-box__body__ul__li__ul__li
-                      .products-detail-page__main__head__contents__top__item-box__body__ul__li__ul__li__img
-                        = image_tag "icon-02.png", width: "75px",height: "87px"
-                    .products-detail-page__main__head__contents__top__item-box__body__ul__li__ul__li
-                      .products-detail-page__main__head__contents__top__item-box__body__ul__li__ul__li__img
-                        = image_tag "icon-02.png", width: "75px",height: "87px"
-            .products-detail-page__main__head__contents__top__item-box__price
-              %span
-                ¥10000
-              .products-detail-page__main__head__contents__top__item-box__price__detail
-                (税込)送料込み
-            .products-detail-page__main__head__contents__top__item-box__comments
-              親譲りの無鉄砲で小供の時から損ばかりしている。 小学校に居る時分学校の二階から飛び降りて一週間ほど腰を抜かした事がある。 なぜそんな無闇をしたと聞く人があるかも知れぬ。別段深い理由でもない。新築の二階から首を出していたら、同級生の一人が冗談に、いくら威張っても、そこから飛び降りる事は出来まい。 弱虫やーい。と囃したからである。小使に負ぶさって帰って来た時、おやじが大きな眼をして二階ぐらいから飛び降りて腰
-            .products-detail-page__main__head__contents__top__item-box__table
-              %table
-                %tbody
-                  %tr
-                    %th
-                      出品者
-                      %td
-                        hoge
-                  %tr
-                    %th
-                      カテゴリー
-                      %td
-                        レディース
-                        %br
-                        トップス
-                        %br
-                        Tシャツ/カットソー(半袖/袖なし)
-                  %tr
-                    %th
-                      ブランド
-                      %td
-                  %tr
-                    %th
-                      商品のサイズ
-                      %td
-                  %tr
-                    %th
-                      商品の状態
-                      %td
-                        新品/未使用
-                  %tr
-                    %th
-                      配送料の負担
-                      %td
-                        送料込み（出品者負担）
-                  %tr
-                    %th
-                      発送元の地域
-                      %td
-                        青森県
-                  %tr
-                    %th
-                      発送日の目安
-                      %td
-                        1-2日で発送
-            .products-detail-page__main__head__contents__top__item-box__option-area
-              %ul.like
-                %li.like-btn
-                  <i class="fas fa-star"></i>
-                  お気に入り 0
-              %ul.tsuho
-                %li.tsuho-btn
-                  %a
-                  <i class="fas fa-flag"></i>
-                  不適切な商品の通報
-          .products-detail-page__main__head__contents__top__comment-box
-            .products-detail-page__main__head__contents__top__comment-box__contents
-            .form
-              %textarea
-                コメントコメントコメントコメント
-              .products-detail-page__main__head__contents__top__comment-box__notice-msg
-                相手のことを考え丁寧なコメントを心がけましょう。
-                %br
-                不快な言葉遣いなどは利用制限や退会処分となることがあります。
-              .products-detail-page__main__head__contents__top__comment-box__btn
-                <i class="fas fa-comment"></i>
-                コメントする
-        .products-detail-page__main__head__contents__links
-          .products-detail-page__main__head__contents__links__before
-            %li
-              <i class="fas fa-angle-left"></i>
-              %span
-                前の商品
-          .products-detail-page__main__head__contents__links__after
-            %li
-              後ろの商品
-              %span
-                <i class="fas fa-angle-right"></i>
-        .products-detail-page__main__head__contents__related-items
-          %a
-            レディースをもっと見る
-.wrapper
+    .products-detail-page__main__head__contents
+      .products-detail-page__main__head__contents__top__item-box
+        .products-detail-page__main__head__contents__top__item-box__name
+          product1
+        .products-detail-page__main__head__contents__top__item-box__body
+          %ul#slider.products-detail-page__main__head__contents__top__item-box__body__ul
+            - @product_images.each do |pic|
+              %li.slider__item
+                = image_tag pic.image, height:"346px"
+
+          %ul#slider__thumbnail.products-detail-page__main__head__contents__top__item-box__body__ul
+            - @product_images.each do |pic|
+              %li.slider__thumbnail--item
+                = image_tag pic.image, width: "75px",height: "87px"
+        .products-detail-page__main__head__contents__top__item-box__price
+          %span
+            ¥10000
+          .products-detail-page__main__head__contents__top__item-box__price__detail
+            (税込)送料込み
+        .products-detail-page__main__head__contents__top__item-box__comments
+          親譲りの無鉄砲で小供の時から損ばかりしている。 小学校に居る時分学校の二階から飛び降りて一週間ほど腰を抜かした事がある。 なぜそんな無闇をしたと聞く人があるかも知れぬ。別段深い理由でもない。新築の二階から首を出していたら、同級生の一人が冗談に、いくら威張っても、そこから飛び降りる事は出来まい。 弱虫やーい。と囃したからである。小使に負ぶさって帰って来た時、おやじが大きな眼をして二階ぐらいから飛び降りて腰
+        .products-detail-page__main__head__contents__top__item-box__table
+          %table
+            %tbody
+              %tr
+                %th
+                  出品者
+                  %td
+                    hoge
+              %tr
+                %th
+                  カテゴリー
+                  %td
+                    レディース
+                    %br
+                    トップス
+                    %br
+                    Tシャツ/カットソー(半袖/袖なし)
+              %tr
+                %th
+                  ブランド
+                  %td
+              %tr
+                %th
+                  商品のサイズ
+                  %td
+              %tr
+                %th
+                  商品の状態
+                  %td
+                    新品/未使用
+              %tr
+                %th
+                  配送料の負担
+                  %td
+                    送料込み（出品者負担）
+              %tr
+                %th
+                  発送元の地域
+                  %td
+                    青森県
+              %tr
+                %th
+                  発送日の目安
+                  %td
+                    1-2日で発送
+        .products-detail-page__main__head__contents__top__item-box__option-area
+          %ul.like
+            %li.like-btn
+              <i class="fas fa-star"></i>
+              お気に入り 0
+          %ul.tsuho
+            %li.tsuho-btn
+              %a
+              <i class="fas fa-flag"></i>
+              不適切な商品の通報
+      .products-detail-page__main__head__contents__top__comment-box
+        .products-detail-page__main__head__contents__top__comment-box__contents
+        .form
+          %textarea
+            コメントコメントコメントコメント
+          .products-detail-page__main__head__contents__top__comment-box__notice-msg
+            相手のことを考え丁寧なコメントを心がけましょう。
+            %br
+            不快な言葉遣いなどは利用制限や退会処分となることがあります。
+          .products-detail-page__main__head__contents__top__comment-box__btn
+            <i class="fas fa-comment"></i>
+            コメントする
+      .products-detail-page__main__head__contents__links
+        .products-detail-page__main__head__contents__links__before
+          %li
+            <i class="fas fa-angle-left"></i>
+            %span
+              前の商品
+        .products-detail-page__main__head__contents__links__after
+          %li
+            後ろの商品
+            %span
+              <i class="fas fa-angle-right"></i>
+      .products-detail-page__main__head__contents__related-items
+        %a
+          レディースをもっと見る
+.products-detail-page__wrapper
   = render "shared/app-banner"
   = render "shared/footer"
   = render "shared/purchase-btn"

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -40,6 +40,13 @@
             ¥10000
           .products-detail-page__main__head__contents__top__item-box__price__detail
             (税込)送料込み
+        .products-detail-page__purchase-btn
+          - if@product_info.user_id == current_user.id
+            =link_to user_path(current_user.id) do
+              商品を編集・削除する
+          - else
+            =link_to product_purchases_path(params[:id]) do
+              購入画面に進む
         .products-detail-page__main__head__contents__top__item-box__comments
           親譲りの無鉄砲で小供の時から損ばかりしている。 小学校に居る時分学校の二階から飛び降りて一週間ほど腰を抜かした事がある。 なぜそんな無闇をしたと聞く人があるかも知れぬ。別段深い理由でもない。新築の二階から首を出していたら、同級生の一人が冗談に、いくら威張っても、そこから飛び降りる事は出来まい。 弱虫やーい。と囃したからである。小使に負ぶさって帰って来た時、おやじが大きな眼をして二階ぐらいから飛び降りて腰
         .products-detail-page__main__head__contents__top__item-box__table

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -95,12 +95,12 @@
         .products-detail-page__main__head__contents__top__item-box__option-area
           %ul.like
             %li.like-btn
-              <i class="fas fa-star"></i>
+              = icon('fas','star')
               お気に入り 0
           %ul.tsuho
             %li.tsuho-btn
               %a
-              <i class="fas fa-flag"></i>
+              = icon('fas','flag')
               不適切な商品の通報
       .products-detail-page__main__head__contents__top__comment-box
         .products-detail-page__main__head__contents__top__comment-box__contents
@@ -112,19 +112,19 @@
             %br
             不快な言葉遣いなどは利用制限や退会処分となることがあります。
           .products-detail-page__main__head__contents__top__comment-box__btn
-            <i class="fas fa-comment"></i>
+            = icon('fas','comment')
             コメントする
       .products-detail-page__main__head__contents__links
         .products-detail-page__main__head__contents__links__before
           %li
-            <i class="fas fa-angle-left"></i>
+            = icon('fas','angle-left')
             %span
               前の商品
         .products-detail-page__main__head__contents__links__after
           %li
             後ろの商品
             %span
-              <i class="fas fa-angle-right"></i>
+              = icon('fas','angle-right')
       .products-detail-page__main__head__contents__related-items
         %a
           レディースをもっと見る

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -7,24 +7,24 @@
       %li
         <i class="fas fa-angle-right"></i>
       %li
-        レディース
+        = @category.root.name
       %li
         <i class="fas fa-angle-right"></i>
       %li
-        トップス
+        = @category.parent.name
       %li
         <i class="fas fa-angle-right"></i>
       %li
-        Tシャツ/カットソー(半袖/袖なし)
+        = @category.name
       %li
         <i class="fas fa-angle-right"></i>
       %li
-        product1
+        = @product_info.name
   .products-detail-page__main
     .products-detail-page__main__head__contents
       .products-detail-page__main__head__contents__top__item-box
         .products-detail-page__main__head__contents__top__item-box__name
-          product1
+          = @product_info.name
         .products-detail-page__main__head__contents__top__item-box__body
           %ul#slider.products-detail-page__main__head__contents__top__item-box__body__ul
             - @product_images.each do |pic|
@@ -37,9 +37,9 @@
                 = image_tag pic.image, width: "75px",height: "87px"
         .products-detail-page__main__head__contents__top__item-box__price
           %span
-            ¥10000
+            = "¥" + @product_info.price.to_s
           .products-detail-page__main__head__contents__top__item-box__price__detail
-            (税込)送料込み
+            = "(税込)" + @product_info.delivery_charge
         .products-detail-page__purchase-btn
           - if@product_info.user_id == current_user.id
             =link_to user_path(current_user.id) do
@@ -48,7 +48,8 @@
             =link_to product_purchases_path(params[:id]) do
               購入画面に進む
         .products-detail-page__main__head__contents__top__item-box__comments
-          親譲りの無鉄砲で小供の時から損ばかりしている。 小学校に居る時分学校の二階から飛び降りて一週間ほど腰を抜かした事がある。 なぜそんな無闇をしたと聞く人があるかも知れぬ。別段深い理由でもない。新築の二階から首を出していたら、同級生の一人が冗談に、いくら威張っても、そこから飛び降りる事は出来まい。 弱虫やーい。と囃したからである。小使に負ぶさって帰って来た時、おやじが大きな眼をして二階ぐらいから飛び降りて腰
+          = @product_info.description
+
         .products-detail-page__main__head__contents__top__item-box__table
           %table
             %tbody
@@ -56,44 +57,41 @@
                 %th
                   出品者
                   %td
-                    hoge
+                    = @product_info.user.nickname
               %tr
                 %th
                   カテゴリー
                   %td
-                    レディース
+                    = @category.root.name
                     %br
-                    トップス
+                    = @category.parent.name
                     %br
-                    Tシャツ/カットソー(半袖/袖なし)
+                    = @category.name
               %tr
                 %th
                   ブランド
                   %td
-              %tr
-                %th
-                  商品のサイズ
-                  %td
+                    = @brand.name
               %tr
                 %th
                   商品の状態
                   %td
-                    新品/未使用
+                    = @product_info.condition
               %tr
                 %th
                   配送料の負担
                   %td
-                    送料込み（出品者負担）
+                    = @product_info.delivery_charge
               %tr
                 %th
                   発送元の地域
                   %td
-                    青森県
+                    = @product_info.delivery_origin
               %tr
                 %th
                   発送日の目安
                   %td
-                    1-2日で発送
+                    = @product_info.shipping_date
         .products-detail-page__main__head__contents__top__item-box__option-area
           %ul.like
             %li.like-btn

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -5,19 +5,19 @@
       %li
         FURIMA
       %li
-        <i class="fas fa-angle-right"></i>
+        = icon('fas','angle-right')
       %li
         = @category.root.name
       %li
-        <i class="fas fa-angle-right"></i>
+        = icon('fas','angle-right')
       %li
         = @category.parent.name
       %li
-        <i class="fas fa-angle-right"></i>
+        = icon('fas','angle-right')
       %li
         = @category.name
       %li
-        <i class="fas fa-angle-right"></i>
+        = icon('fas','angle-right')
       %li
         = @product_info.name
   .products-detail-page__main

--- a/app/views/tests/index.html.haml
+++ b/app/views/tests/index.html.haml
@@ -2,7 +2,7 @@
 
 = form_for [@test],url: tests_path,method: "POST"  do |f|
     %p
-        = f.text_field :name, value: "商品名テスト"
+        = f.text_field :name ,value: "商品名テスト",data: {index: 'index-number'}
     %p
         = f.text_field :description, value: "説明テスト"
     %p

--- a/app/views/tests/index.html.haml
+++ b/app/views/tests/index.html.haml
@@ -22,3 +22,4 @@
         = f.submit value: "登録する"
 
 
+


### PR DESCRIPTION
# WHAT
- 商品詳細ページに以下の機能を実装
  - 商品画像DBから商品画像、その他情報を取得し表示
  - 画像をSlickを使ってスライド表示。サムネイルをクリックするとメインの画像が切り替わる。
  - 出品したユーザーの場合は購入ボタンを出さない
  - 出品したユーザーの場合、商品編集・削除ボタンが出る（編集・削除機能未実装のためマイページにリンクしています。今後、マイページに編集削除機能を追加予定です）

# WHY
- 商品詳細ページに自動で各商品の情報を反映させるため
- 出品ユーザー以外が購入できるようにするため
- 出品ユーザーは購入できず、編集・削除に遷移できるようにするため